### PR TITLE
Adding queries from past year 

### DIFF
--- a/sql/2021/media/big_non_custom_metrics.sql
+++ b/sql/2021/media/big_non_custom_metrics.sql
@@ -1,0 +1,37 @@
+#standardSQL
+# non custom metrics sql that uses regexp on response bodies
+# img src vs data-uri
+# count rel=preconnect
+# video with src
+# video with source
+# figure
+# figure with figcaption
+
+SELECT
+  client,
+  COUNTIF(has_img_data_uri) / COUNTIF(has_img_src) AS pages_with_img_data_uri_pct,
+  COUNTIF(rel_preconnect) / COUNT(0) AS pages_with_rel_preconnect_pct,
+  COUNTIF(has_video_src) / COUNT(0) AS pages_with_video_src_pct,
+  COUNTIF(has_video_source) / COUNT(0) AS pages_with_video_source_pct,
+  COUNTIF(has_figure) / COUNT(0) AS pages_with_figure_pct,
+  COUNTIF(has_figcaption) / COUNT(0) AS pages_with_figcaption_pct
+FROM (
+  SELECT
+    client,
+    page,
+    REGEXP_CONTAINS(body, r'(?i)<img[^><]*src=(?:\"|\')*data[:]image/(?:\"|\')*[^><]*>') AS has_img_data_uri,
+    REGEXP_CONTAINS(body, r'(?i)<img[^><]*src=[^><]*>') AS has_img_src,
+    REGEXP_CONTAINS(body, r'(?i)<link[^><]*rel=(?:\"|\')*preconnect/(?:\"|\')*[^><]*>') AS rel_preconnect,
+    REGEXP_CONTAINS(body, r'(?i)<video[^><]*src=[^><]*>') AS has_video_src,
+    REGEXP_CONTAINS(body, r'(?i)<video[^><]*>.*?<source[^><]*>.*?</video>') AS has_video_source,
+    REGEXP_CONTAINS(body, r'(?i)<figure[^><]*>') AS has_figure,
+    REGEXP_CONTAINS(body, r'(?i)<figure[^><]*>.*?<figcaption[^><]*>.*?</figure>') AS has_figcaption
+  FROM
+    `httparchive.almanac.summary_response_bodies`
+  WHERE
+    date = '2021-08-01' AND
+    firstHtml)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/bytes_per_pixel.sql
+++ b/sql/2021/media/bytes_per_pixel.sql
@@ -1,0 +1,89 @@
+#standardSQL
+# Bytes per pixel per image format
+CREATE TEMPORARY FUNCTION getImages(payload STRING)
+RETURNS ARRAY<STRUCT<url STRING, naturalWidth INT64, naturalHeight INT64, width INT64, height INT64>> LANGUAGE js AS '''
+try {
+  var $ = JSON.parse(payload);
+  var images = JSON.parse($._Images) || [];
+  return images.map(({url, naturalHeight, naturalWidth, width, height}) => ({url, naturalHeight: Number.parseInt(naturalHeight) || 0, naturalWidth: Number.parseInt(naturalWidth) || 0, width: Number.parseInt(width) || 0, height: Number.parseInt(height) || 0}));
+} catch (e) {}
+return null;
+''';
+
+SELECT
+  a.client,
+  imageType,
+  count(0) AS count,
+  APPROX_QUANTILES(if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 1000)[OFFSET(100)] AS pixels_p10,
+  APPROX_QUANTILES(if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 1000)[OFFSET(250)] AS pixels_p25,
+  APPROX_QUANTILES(if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 1000)[OFFSET(500)] AS pixels_p50,
+  APPROX_QUANTILES(if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 1000)[OFFSET(750)] AS pixels_p75,
+  APPROX_QUANTILES(if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 1000)[OFFSET(900)] AS pixels_p90,
+  APPROX_QUANTILES(bytes, 1000)[OFFSET(100)] AS bytes_p10,
+  APPROX_QUANTILES(bytes, 1000)[OFFSET(250)] AS bytes_p25,
+  APPROX_QUANTILES(bytes, 1000)[OFFSET(500)] AS bytes_p50,
+  APPROX_QUANTILES(bytes, 1000)[OFFSET(750)] AS bytes_p75,
+  APPROX_QUANTILES(bytes, 1000)[OFFSET(900)] AS bytes_p90,
+  APPROX_QUANTILES(round(bytes/if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 4), 1000)[OFFSET(100)] AS bpp_p10,
+  APPROX_QUANTILES(round(bytes/if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 4), 1000)[OFFSET(250)] AS bpp_p25,
+  APPROX_QUANTILES(round(bytes/if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 4), 1000)[OFFSET(500)] AS bpp_p50,
+  APPROX_QUANTILES(round(bytes/if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 4), 1000)[OFFSET(750)] AS bpp_p75,
+  APPROX_QUANTILES(round(bytes/if(imageType = 'svg' AND pixels > 0, pixels, naturalPixels), 4), 1000)[OFFSET(900)] AS bpp_p90
+FROM
+(
+  SELECT
+    _TABLE_SUFFIX AS client,
+    p.url AS page,
+    image.url AS url,
+    image.width AS width,
+    image.height AS height,
+    image.naturalWidth AS naturalWidth,
+    image.naturalHeight AS naturalHeight,
+    IFNULL(image.width, 0) * IFNULL(image.height, 0) AS pixels,
+    IFNULL(image.naturalWidth, 0) * IFNULL(image.naturalHeight, 0) AS naturalPixels
+  FROM
+    `httparchive.pages.2021_08_01_*` p
+    CROSS JOIN UNNEST(getImages(payload)) AS image
+  WHERE
+    image.naturalHeight > 0 AND
+    image.naturalWidth > 0
+) a
+LEFT JOIN
+(
+    SELECT
+      client,
+      page,
+      url,
+      NULLIF(if(REGEXP_CONTAINS(mimetype, r'(?i)^application|^applicaton|^binary|^image$|^multipart|^media|^$|^text/html|^text/plain|\d|array|unknown|undefined|\*|string|^img|^images|^text|\%2f|\(|ipg$|jpe$|jfif'), format, LOWER(regexp_replace(regexp_replace(mimetype, r'(?is).*image[/\\](?:x-)?|[\."]|[ +,;]+.*$', ''), r'(?i)pjpeg|jpeg', 'jpg'))), '') AS imageType,
+      respSize AS bytes
+    FROM `httparchive.almanac.requests`
+
+    WHERE
+      # many 404s and redirects show up as image/gif
+      status = 200 AND
+
+      # we are trying to catch images. WPO populates the format for media but it uses a file extension guess.
+      #So we exclude mimetypes that aren't image or where the format couldn't be guessed by WPO
+     (format <> '' OR mimetype LIKE 'image%') AND
+
+      # many image/gifs are really beacons with 1x1 pixel, but svgs can get caught in the mix
+     (respSize > 1500 OR REGEXP_CONTAINS(mimetype, r'svg')) AND
+
+      # strip favicon requests
+     format <> 'ico' AND
+
+      # strip video mimetypes and other favicons
+      NOT REGEXP_CONTAINS(mimetype, r'video|ico')
+) b
+ON (b.client = a.client AND a.page = b.page AND a.url = b.url)
+
+WHERE
+  naturalPixels > 0 AND
+  bytes > 0 AND
+  imageType IN ('jpg', 'png', 'webp', 'gif', 'svg')
+GROUP BY
+  client,
+  imageType
+ORDER BY
+  client DESC
+  imageType DESC;

--- a/sql/2021/media/image_alt.sql
+++ b/sql/2021/media/image_alt.sql
@@ -7,7 +7,9 @@ RETURNS STRUCT<
   total INT64,
   alt_missing INT64, 
   alt_blank INT64,
-  alt_present INT64
+  alt_present INT64,
+  decode_lazy INT64
+
 > LANGUAGE js AS '''
 var result = {};
 try {
@@ -19,6 +21,7 @@ try {
     result.alt_missing = markup.images.img.alt.missing;
     result.alt_blank = markup.images.img.alt.blank;
     result.alt_present = markup.images.img.alt.present;
+    result.decode_lazy = markup.images.img.decoding || 0;
 
 } catch (e) {}
 return result;
@@ -30,10 +33,12 @@ SELECT
   SAFE_DIVIDE(COUNTIF(markup_info.alt_missing > 0), COUNT(0)) AS pages_with_alt_missing_pct,
   SAFE_DIVIDE(COUNTIF(markup_info.alt_blank > 0), COUNT(0)) AS pages_with_alt_blank_pct,
   SAFE_DIVIDE(COUNTIF(markup_info.alt_present > 0), COUNT(0)) AS pages_with_alt_present_pct,
+  SAFE_DIVIDE(COUNTIF(markup_info.decode_lazy > 0), COUNT(0)) as pages_with_decode_pct,
   SUM(markup_info.total) AS img_total,
   SAFE_DIVIDE(SUM(markup_info.alt_missing), SUM(markup_info.total)) AS imgs_alt_missing_pct,
   SAFE_DIVIDE(SUM(markup_info.alt_blank), SUM(markup_info.total)) AS img_alt_blank_pct,
-  SAFE_DIVIDE(SUM(markup_info.alt_present), SUM(markup_info.total)) AS img_alt_present_pct
+  SAFE_DIVIDE(SUM(markup_info.alt_present), SUM(markup_info.total)) AS img_alt_present_pct,
+  SAFE_DIVIDE(SUM(markup_info.decode_lazy), SUM(markup_info.total)) AS img_decode_pct
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,

--- a/sql/2021/media/image_alt.sql
+++ b/sql/2021/media/image_alt.sql
@@ -1,0 +1,47 @@
+#standardSQL
+# usage of alt text in images
+
+# returns all the data we need from _markup
+CREATE TEMPORARY FUNCTION get_markup_info(markup_string STRING)
+RETURNS STRUCT<
+  total INT64,
+  alt_missing INT64, 
+  alt_blank INT64,
+  alt_present INT64
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var markup = JSON.parse(markup_string);
+
+    if (Array.isArray(markup) || typeof markup != 'object') return result;
+	
+    result.total = markup.images.img.total;
+    result.alt_missing = markup.images.img.alt.missing;
+    result.alt_blank = markup.images.img.alt.blank;
+    result.alt_present = markup.images.img.alt.present;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(markup_info.total > 0), COUNT(0)) AS pages_with_img_pct,
+  SAFE_DIVIDE(COUNTIF(markup_info.alt_missing > 0), COUNT(0)) AS pages_with_alt_missing_pct,
+  SAFE_DIVIDE(COUNTIF(markup_info.alt_blank > 0), COUNT(0)) AS pages_with_alt_blank_pct,
+  SAFE_DIVIDE(COUNTIF(markup_info.alt_present > 0), COUNT(0)) AS pages_with_alt_present_pct,
+  SUM(markup_info.total) AS img_total,
+  SAFE_DIVIDE(SUM(markup_info.alt_missing), SUM(markup_info.total)) AS imgs_alt_missing_pct,
+  SAFE_DIVIDE(SUM(markup_info.alt_blank), SUM(markup_info.total)) AS img_alt_blank_pct,
+  SAFE_DIVIDE(SUM(markup_info.alt_present), SUM(markup_info.total)) AS img_alt_present_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    get_markup_info(JSON_EXTRACT_SCALAR(payload, '$._markup')) AS markup_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/image_dimension_by_device.sql
+++ b/sql/2021/media/image_dimension_by_device.sql
@@ -1,0 +1,37 @@
+#standardSQL
+# Taken from Performance 2020 chapter
+# Removed the condition to look for only ECommerce
+
+## $4.11 run
+
+CREATE TEMPORARY FUNCTION getImageDimensions(payload STRING)
+RETURNS ARRAY<STRUCT<height INT64, width INT64>> LANGUAGE js AS '''
+try {
+  var $ = JSON.parse(payload);
+  var images = JSON.parse($._Images);
+  return images.map(i => ({height: i.naturalHeight, width: i.naturalWidth}));
+} catch (e) {
+  return [];
+}
+''';
+
+SELECT
+  percentile,
+  category,
+  _TABLE_SUFFIX AS client,
+  APPROX_QUANTILES(image.width, 1000)[OFFSET(percentile * 10)] AS image_width,
+  APPROX_QUANTILES(image.height, 1000)[OFFSET(percentile * 10)] AS image_height
+FROM
+  `httparchive.pages.2021_08_01_*`
+JOIN
+  `httparchive.technologies.2021_08_01_*`
+USING (_TABLE_SUFFIX, url),
+UNNEST(getImageDimensions(payload)) AS image,
+UNNEST([10, 25, 50, 75, 90]) AS percentile
+GROUP BY
+  percentile,
+  client,
+  category
+ORDER BY
+  percentile,
+  client

--- a/sql/2021/media/image_mimetype_ext.sql
+++ b/sql/2021/media/image_mimetype_ext.sql
@@ -1,0 +1,25 @@
+#standardSQL
+# images mimetype vs extension
+SELECT
+  client,
+  ext,
+  mimetype,
+  COUNT(0) AS ext_mime_image_count,
+  SUM(COUNT(0)) OVER (PARTITION BY client) AS total_images,
+  SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS total_image_pct,
+  SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client, ext)) AS ext_pct,
+  SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client, mimetype)) AS mime_pct
+FROM
+  `httparchive.almanac.requests`
+WHERE
+  date = '2021-08-01' and
+  type = 'image'
+GROUP BY
+  client,
+  ext,
+  mimetype
+HAVING
+  ext_mime_image_count > 10000
+ORDER BY
+  ext_mime_image_count DESC,
+  client

--- a/sql/2021/media/image_srcset_candidates.sql
+++ b/sql/2021/media/image_srcset_candidates.sql
@@ -1,0 +1,41 @@
+#standardSQL
+# images srcset candidates average
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_srcset_all INT64, 
+  num_srcset_candidates_avg INT64
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+	
+    result.num_srcset_all = media.num_srcset_all;
+    result.num_srcset_candidates_avg = 
+	    media.num_srcset_all == 0? 0: (media.num_srcset_candidates / media.num_srcset_all);
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_all > 0), COUNT(0)) AS pages_with_srcset_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_candidates_avg >= 1 AND media_info.num_srcset_candidates_avg <=3), COUNTIF(media_info.num_srcset_all > 0)) AS pages_with_srcset_candidates_1_3_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_candidates_avg >= 1 AND media_info.num_srcset_candidates_avg <= 5), COUNTIF(media_info.num_srcset_all > 0)) AS pages_with_srcset_candidates_1_5_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_candidates_avg > 5 AND media_info.num_srcset_candidates_avg <= 10), COUNTIF(media_info.num_srcset_all > 0)) AS pages_with_srcset_candidates_5_10_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_candidates_avg > 10 AND media_info.num_srcset_candidates_avg <= 15), COUNTIF(media_info.num_srcset_all > 0)) AS pages_with_srcset_candidates_10_15_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_candidates_avg > 15 AND media_info.num_srcset_candidates_avg <= 20), COUNTIF(media_info.num_srcset_all > 0)) AS pages_with_srcset_candidates_15_20_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/image_srcset_descriptor.sql
+++ b/sql/2021/media/image_srcset_descriptor.sql
@@ -1,0 +1,41 @@
+#standardSQL
+# images with srcset descriptor_x descriptor_w
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_srcset_all INT64, 
+  num_srcset_descriptor_x INT64,
+  num_srcset_descriptor_w INT64
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+	
+    result.num_srcset_all = media.num_srcset_all;
+    result.num_srcset_descriptor_x = media.num_srcset_descriptor_x;
+	result.num_srcset_descriptor_w = media.num_srcset_descriptor_w;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_all > 0), COUNT(0)) AS pages_with_srcset_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_descriptor_x > 0), COUNT(0)) AS pages_with_srcset_descriptor_x_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_descriptor_w > 0), COUNT(0)) AS pages_with_srcset_descriptor_w_pct,
+  SAFE_DIVIDE(SUM(media_info.num_srcset_descriptor_x), SUM(media_info.num_srcset_all)) AS instances_of_srcset_descriptor_x_pct,
+  SAFE_DIVIDE(SUM(media_info.num_srcset_descriptor_w), SUM(media_info.num_srcset_all)) AS instances_of_srcset_descriptor_w_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/image_srcset_sizes.sql
+++ b/sql/2021/media/image_srcset_sizes.sql
@@ -1,0 +1,39 @@
+#standardSQL
+# images with srcset w/wo sizes
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_srcset_all INT64, 
+  num_srcset_sizes INT64
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+	
+    result.num_srcset_all = media.num_srcset_all;
+    result.num_srcset_sizes = media.num_srcset_sizes;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_all > 0), COUNT(0)) AS pages_with_srcset_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_srcset_sizes > 0), COUNT(0)) AS pages_with_srcset_sizes_pct,
+  SAFE_DIVIDE((COUNTIF(media_info.num_srcset_all > 0) - COUNTIF(media_info.num_srcset_sizes > 0)), COUNT(0)) AS pages_with_srcset_wo_sizes_pct,
+  SAFE_DIVIDE(SUM(media_info.num_srcset_sizes), SUM(media_info.num_srcset_all)) AS instances_of_srcset_sizes_pct,
+  SAFE_DIVIDE((SUM(media_info.num_srcset_all) - SUM(media_info.num_srcset_sizes)), SUM(media_info.num_srcset_all)) AS instances_of_srcset_wo_sizes_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/img_covid_in_path.sql
+++ b/sql/2021/media/img_covid_in_path.sql
@@ -1,0 +1,22 @@
+#standardSQL
+# images with covid in path - average size
+SELECT
+  client,
+  LOWER(ext) AS ext,
+  COUNT(0) AS ext_count,
+  COUNTIF(REGEXP_CONTAINS(LOWER(url), r'[^/]*?[:]//[^/]*?/.*?covid')) AS ext_count_covid,
+  SAFE_DIVIDE(SUM(respSize), COUNT(0)) AS avg_size,
+  SAFE_DIVIDE(SUM(IF(REGEXP_CONTAINS(LOWER(url), r'[^/]*?[:]//[^/]*?/.*?covid'), respSize, 0)), COUNTIF(REGEXP_CONTAINS(LOWER(url), r'[^/]*?[:]//[^/]*?/.*?covid'))) AS avg_size_covid
+FROM
+  `httparchive.almanac.requests`
+WHERE
+  date = '2021-08-01' AND
+  type = 'image'
+GROUP BY
+  client,
+  ext
+HAVING
+  ext_count_covid > 100
+ORDER BY
+  client,
+  ext_count_covid DESC;

--- a/sql/2021/media/img_with_dimensions.sql
+++ b/sql/2021/media/img_with_dimensions.sql
@@ -1,0 +1,45 @@
+#standardSQL
+# usage meta open graph
+
+# extracts the data about width, height and alt from the new customer metric
+# using this, counts and reports on the usage for each attribute
+CREATE TEMPORARY FUNCTION get_image_info(responsiveString STRING)
+RETURNS ARRAY<STRUCT<hasWidth INT64, hasHeight INT64, hasAlt INT64, hasReservedLayoutDimension INT64>>
+LANGUAGE js AS '''
+    let result = Array()
+    const responsiveImages = JSON.parse(responsiveString)
+    if(responsiveImages &&  responsiveImages['responsive-images']){
+    for(const image of responsiveImages["responsive-images"]){        
+        result.push({
+            hasWidth: image.hasWidth ? 1 : 0,
+            hasHeight: image.hasHeight ? 1 : 0,
+            hasAlt: image.hasAlt ? 1 : 0,
+            hasReservedLayoutDimension: image.reservedLayoutDimensions ? 1 : 0
+            })
+    }}
+    return result
+''';
+SELECT 
+    client,
+    COUNT(0) AS images,
+    COUNTIF(hasWidth = 1) as hasWidth,
+    COUNTIF(hasHeight=1) as hasHeight,
+    COUNTIF(hasAlt=1) as hasAlt,
+    COUNTIF(hasReservedLayoutDimension=1) as hasDimensions,
+    SAFE_DIVIDE(COUNTIF(hasWidth = 1), COUNT(0)) as percHasWidth,
+    SAFE_DIVIDE(COUNTIF(hasHeight = 1), COUNT(0)) as percHasHeight,
+    SAFE_DIVIDE(COUNTIF(hasAlt = 1), COUNT(0)) as percHasAlt,
+    SAFE_DIVIDE(COUNTIF(hasReservedLayoutDimension=1), COUNT(0)) as percHasDimensions
+FROM  (
+    SELECT
+        _TABLE_SUFFIX AS client,
+        hasWidth,
+        hasHeight,
+        hasAlt,
+        hasReservedLayoutDimension        
+    FROM 
+        `httparchive.pages.2021_08_01_*`, 
+        UNNEST(get_image_info(JSON_VALUE(payload, '$._responsive_images')))
+)
+GROUP BY client
+    

--- a/sql/2021/media/lazy_loading_usage.sql
+++ b/sql/2021/media/lazy_loading_usage.sql
@@ -9,8 +9,8 @@ SELECT
 FROM (
   SELECT
     _TABLE_SUFFIX AS client,
-    SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.images.imgs.total') AS INT64) AS total_img,
-    SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.images.imgs.attribute_usage_count.loading') AS INT64) AS total_loading_attribute,
+    SAFE_CAST(JSON_VALUE(JSON_VALUE(payload, '$._almanac'), '$.images.imgs.total') AS INT64) AS total_img,
+    SAFE_CAST(JSON_VALUE(JSON_VALUE(payload, '$._almanac'), '$.images.imgs.attribute_usage_count.loading') AS INT64) AS total_loading_attribute,
   FROM
     `httparchive.pages.2021_08_01_*`
 )

--- a/sql/2021/media/lazy_loading_usage.sql
+++ b/sql/2021/media/lazy_loading_usage.sql
@@ -1,0 +1,18 @@
+#standardSQL
+# Usage of native lazy loading
+SELECT
+  client,
+  COUNTIF(total_img > 0) AS sites_with_images,
+
+  COUNTIF(total_loading_attribute > 0) AS sites_using_loading_attribute,
+  COUNTIF(total_loading_attribute > 0) / COUNTIF(total_img > 0) AS pct_sites_using_loading_attribute
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.images.imgs.total') AS INT64) AS total_img,
+    SAFE_CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._almanac'), '$.images.imgs.attribute_usage_count.loading') AS INT64) AS total_loading_attribute,
+  FROM
+    `httparchive.pages.2021_08_01_*`
+)
+GROUP BY
+  client

--- a/sql/2021/media/meta_open_graph.sql
+++ b/sql/2021/media/meta_open_graph.sql
@@ -1,0 +1,43 @@
+#standardSQL
+# usage meta open graph
+
+# returns all the data we need from _almanac
+CREATE TEMPORARY FUNCTION get_meta_og_info(almanac_string STRING)
+RETURNS STRUCT<
+  meta_og_image BOOLEAN,
+  meta_og_video BOOLEAN
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var almanac = JSON.parse(almanac_string);
+
+    if (Array.isArray(almanac) || typeof almanac != 'object') return result;
+
+    result.meta_og_image = false;
+    result.meta_og_video = false;
+    for (var node of almanac['meta-nodes']['nodes']) {
+      if (node['property'] === 'og:image')
+        result.meta_og_image = true;
+      else if (node['property'] === 'og:video')
+        result.meta_og_video = true;
+    }
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  COUNTIF(almanac_info.meta_og_image) / COUNT(0) as meta_og_image_pct,
+  COUNTIF(almanac_info.meta_og_video) / COUNT(0) as meta_og_video_pct,
+  COUNTIF(almanac_info.meta_og_image AND almanac_info.meta_og_video) / COUNT(0) as meta_og_image_video_pct,
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    get_meta_og_info(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client;

--- a/sql/2021/media/meta_open_image_types.sql
+++ b/sql/2021/media/meta_open_image_types.sql
@@ -1,0 +1,52 @@
+#standardSQL
+# meta open graph image types
+
+# returns all the data we need from _almanac
+CREATE TEMPORARY FUNCTION get_meta_og_image_types(almanac_string STRING)
+RETURNS STRUCT<
+  image_types ARRAY<STRING>
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var almanac = JSON.parse(almanac_string);
+
+    if (Array.isArray(almanac) || typeof almanac != 'object') return result;
+
+    for (var node of almanac['meta-nodes']['nodes']) {
+      if (node['property'] === 'og:image') {
+        if (result.image_types == null)
+          result.image_types = [];
+        var url = node['content'];
+        // parse image extension from url
+        // https://www.example.com/filename.ext?param=1234#anchor
+        // first group is for file name, second for extension and 
+        // third one for the remaining of the url
+        var rex = new RegExp('([^/]+)[.]([^/#?&]+)([#?][^/]*)?$');
+        var ext = url.match(rex);
+        result.image_types.push(ext[2].toLowerCase().trim());  
+      }
+    }
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  image_type,
+  COUNT(0) AS image_type_count,
+  SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS image_type_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    get_meta_og_image_types(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
+  FROM
+    `httparchive.pages.2021_08_01_*`),
+  UNNEST(almanac_info.image_types) AS image_type
+GROUP BY
+  client, image_type
+HAVING
+  image_type_count > 100
+ORDER BY
+  client,
+  image_type_count DESC;

--- a/sql/2021/media/meta_open_video_types.sql
+++ b/sql/2021/media/meta_open_video_types.sql
@@ -1,0 +1,52 @@
+#standardSQL
+# meta open graph video types
+
+# returns all the data we need from _almanac
+CREATE TEMPORARY FUNCTION get_meta_og_video_types(almanac_string STRING)
+RETURNS STRUCT<
+  video_types ARRAY<STRING>
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var almanac = JSON.parse(almanac_string);
+
+    if (Array.isArray(almanac) || typeof almanac != 'object') return result;
+
+    for (var node of almanac['meta-nodes']['nodes']) {
+      if (node['property'] === 'og:video') {
+        if (result.video_types == null)
+          result.video_types = [];
+        var url = node['content'];
+        // parse video extension from url
+        // https://www.example.com/filename.ext?param=1234#anchor
+        // first group is for file name, second for extension and 
+        // third one for the remaining of the url
+        var rex = new RegExp('([^/]+)[.]([^/#?&]+)([#?][^/]*)?$');
+        var ext = url.match(rex);
+        result.video_types.push(ext[2].toLowerCase().trim());  
+      }
+    }
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  video_type,
+  COUNT(0) AS video_type_count,
+  SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS video_type_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    get_meta_og_video_types(JSON_EXTRACT_SCALAR(payload, '$._almanac')) AS almanac_info
+  FROM
+    `httparchive.pages.2021_08_01_*`),
+  UNNEST(almanac_info.video_types) AS video_type
+GROUP BY
+  client, video_type
+HAVING
+  video_type_count > 10
+ORDER BY
+  client,
+  video_type_count DESC;

--- a/sql/2021/media/picture_format_distribution.sql
+++ b/sql/2021/media/picture_format_distribution.sql
@@ -1,0 +1,58 @@
+#standardSQL
+# picture formats distribution
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_picture_img INT64,
+  num_picture_formats INT64,
+  picture_formats ARRAY<STRING>
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+
+    // fix "picture_formats":"[]"
+    if (!Array.isArray(media.picture_formats))
+    {
+      media.picture_formats = JSON.parse(media.picture_formats);
+    }
+
+    // skip "picture_formats":[{}]
+    if (media.picture_formats.length == 1 && Object.keys(media.picture_formats[0]).length === 0)
+    {
+      media.picture_formats = [];
+    }
+
+    result.picture_formats = media.picture_formats;
+    result.num_picture_img = media.num_picture_img;
+    result.num_picture_formats = result.picture_formats.length;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_formats > 0), COUNTIF(media_info.num_picture_img > 0)) AS pages_with_picture_formats_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_formats = 1), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_picture_formats_1_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_formats = 2), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_picture_formats_2_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_formats = 3), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_picture_formats_3_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_formats >= 4), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_picture_formats_4_and_more_pct,
+  SAFE_DIVIDE(COUNTIF('image/webp' IN UNNEST(media_info.picture_formats)), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_webp_pct,
+  SAFE_DIVIDE(COUNTIF('image/gif' IN UNNEST(media_info.picture_formats)), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_gif_pct,
+  SAFE_DIVIDE(COUNTIF('image/jpg' IN UNNEST(media_info.picture_formats)), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_jpg_pct,
+  SAFE_DIVIDE(COUNTIF('image/png' IN UNNEST(media_info.picture_formats)), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_png_pct,
+  SAFE_DIVIDE(COUNTIF('image/avif' IN UNNEST(media_info.picture_formats)), COUNTIF(media_info.num_picture_formats > 0)) AS pages_with_avif_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/picture_orientation.sql
+++ b/sql/2021/media/picture_orientation.sql
@@ -1,0 +1,36 @@
+#standardSQL
+# picture using orientation
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_picture_img INT64,
+  num_picture_using_orientation INT64
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+
+    result.num_picture_img = media.num_picture_img;
+    result.num_picture_using_orientation = media.num_picture_using_orientation;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_using_orientation > 0), COUNTIF(media_info.num_picture_img > 0)) AS pages_with_picture_orientation_pct,
+  SAFE_DIVIDE(SUM(media_info.num_picture_using_orientation), SUM(media_info.num_picture_img)) AS occurences_of_picture_orientation_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/picture_using_min_resolution.sql
+++ b/sql/2021/media/picture_using_min_resolution.sql
@@ -1,0 +1,37 @@
+#standardSQL
+# picture using min resolution
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_picture_using_min_resolution  INT64, 
+  num_picture_img INT64
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+	
+    result.num_picture_using_min_resolution = media.num_picture_using_min_resolution;
+    result.num_picture_img = media.num_picture_img;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_img > 0), COUNT(0)) AS pages_with_picture_pct,
+  SAFE_DIVIDE(COUNTIF(media_info.num_picture_using_min_resolution > 0), COUNTIF(media_info.num_picture_img > 0)) AS pages_with_picture_min_resolution_pct,
+  SAFE_DIVIDE(SUM(media_info.num_picture_using_min_resolution), SUM(media_info.num_picture_img)) AS occurences_of_picture_min_resolution_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/pixel_volume.sql
+++ b/sql/2021/media/pixel_volume.sql
@@ -1,0 +1,72 @@
+#standardSQL
+# 04_11b: pixel volume
+CREATE TEMPORARY FUNCTION getCssPixels(payload STRING)
+RETURNS INT64 LANGUAGE js AS '''
+try {
+  let data = JSON.parse(payload);
+  return data.reduce((a, c) => a + (c.width||0)*(c.height||0), 0) || 0;
+}
+catch (e) {}
+return null;
+''';
+
+CREATE TEMPORARY FUNCTION getNaturalPixels(payload STRING)
+RETURNS INT64 LANGUAGE js AS '''
+try {
+  let data = JSON.parse(payload);
+  return data.reduce((a, c) => a + (c.naturalWidth||0)*(c.naturalHeight||0), 0) || 0;
+}
+catch (e) {}
+return null;
+''';
+
+SELECT
+  client,
+  count(0) AS count,
+  any_value(viewportHeight) AS viewportHeight,
+  any_value(viewportWidth) AS viewportWidth,
+  any_value(dpr) AS dpr,
+  any_value(viewportHeight) * any_value(viewportWidth) AS displaypx,
+  APPROX_QUANTILES(cssPixels, 1000)[OFFSET(100)] AS cssPixels_p10,
+  APPROX_QUANTILES(cssPixels, 1000)[OFFSET(250)] AS cssPixels_p25,
+  APPROX_QUANTILES(cssPixels, 1000)[OFFSET(500)] AS cssPixels_p50,
+  APPROX_QUANTILES(cssPixels, 1000)[OFFSET(750)] AS cssPixels_p75,
+  APPROX_QUANTILES(cssPixels, 1000)[OFFSET(900)] AS cssPixels_p90,
+  APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(100)] AS naturalPixels_p10,
+  APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(250)] AS naturalPixels_p25,
+  APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(500)] AS naturalPixels_p50,
+  APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(750)] AS naturalPixels_p75,
+  APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(900)] AS naturalPixels_p90,
+  Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(100)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p10,
+  Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(250)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p25,
+  Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(500)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p50,
+  Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(750)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p75,
+  Round(APPROX_QUANTILES(naturalPixels, 1000)[OFFSET(900)] / (any_value(viewportHeight) * any_value(viewportWidth)), 2) AS pct_p90
+FROM
+(
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url AS page,
+    getCssPixels(JSON_EXTRACT_SCALAR(payload, '$._Images')) AS cssPixels,
+    getNaturalPixels(JSON_EXTRACT_SCALAR(payload, '$._Images')) AS naturalPixels,
+    CAST(JSON_EXTRACT_SCALAR(payload, '$._smallImageCount') AS Int64) AS smallImageCount,
+    CAST(JSON_EXTRACT_SCALAR(payload, '$._bigImageCount') AS Int64) AS bigImageCount,
+    CAST(JSON_EXTRACT_SCALAR(payload, '$._image_total') AS Int64) AS imageBytes,
+    CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Dpi'), '$.dppx') AS Float64) AS dpr,
+    CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Resolution'), '$.absolute.height') AS Float64) AS viewportHeight,
+    CAST(JSON_EXTRACT_SCALAR(json_extract_scalar(payload, '$._Resolution'), '$.absolute.width') AS Float64) AS viewportWidth
+  FROM
+    `httparchive.pages.2021_08_01_*`
+)
+WHERE
+  # it appears the _Images array is populated only from <img> tag requests and not CSS or favicon
+  # likewise the bigImageCount and smallImageCount only track images > 100,000 and < 10,000 respectively.
+  # Meaning images between 10KB and 100KB won't show up in the count
+  # https://github.com/WPO-Foundation/webpagetest/blob/master/www/breakdown.inc#L95
+  cssPixels > 0 AND
+  naturalPixels > 0 AND
+  (smallImageCount > 0 OR bigImageCount > 0)
+GROUP BY
+  client
+ORDER BY
+  client DESC

--- a/sql/2021/media/score_progressive_jpeg.sql
+++ b/sql/2021/media/score_progressive_jpeg.sql
@@ -1,0 +1,21 @@
+#standardSQL
+# percent of pages with score_progressive_jpeg
+# -1, 0 - 25, 25 - 50, 50 - 75, 75 - 100
+
+SELECT
+  client,
+  COUNTIF(score < 0) / COUNT(0) AS percent_negative,
+  COUNTIF(score >= 0 AND score < 25) / COUNT(0) AS percent_0_25,
+  COUNTIF(score >= 25 AND score < 50) / COUNT(0) AS percent_25_50,
+  COUNTIF(score >= 50 AND score < 75) / COUNT(0) AS percent_50_75,
+  COUNTIF(score >= 75 AND score <= 100) / COUNT(0) AS percent_75_100
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    CAST(JSON_EXTRACT(payload, '$._score_progressive_jpeg') AS NUMERIC) AS score
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/video_autoplay_muted.sql
+++ b/sql/2021/media/video_autoplay_muted.sql
@@ -1,0 +1,51 @@
+#standardSQL
+# video autoplay/muted
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_video_nodes INT64,
+  video_nodes_attributes ARRAY<STRING>
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+
+    // fix "video_nodes_attributes":"[]"
+    if (!Array.isArray(media.video_nodes_attributes))
+    {
+      media.video_nodes_attributes = JSON.parse(media.video_nodes_attributes);
+    }
+
+    // skip "video_nodes_attributes":[{}]
+    if (media.video_nodes_attributes.length == 1 && Object.keys(media.video_nodes_attributes[0]).length === 0)
+    {
+      media.video_nodes_attributes = [];
+    }
+
+    result.video_nodes_attributes = media.video_nodes_attributes;
+    result.num_video_nodes = media.num_video_nodes;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_video_nodes > 0), COUNT(0)) AS pages_with_video_nodes_pct,
+  SAFE_DIVIDE(COUNTIF('autoplay' IN UNNEST(media_info.video_nodes_attributes)), COUNTIF(media_info.num_video_nodes > 0)) AS pages_with_video_autoplay_pct,
+  SAFE_DIVIDE(COUNTIF('muted' IN UNNEST(media_info.video_nodes_attributes)), COUNTIF(media_info.num_video_nodes > 0)) AS pages_with_video_muted_pct,
+  SAFE_DIVIDE(COUNTIF('autoplay' IN UNNEST(media_info.video_nodes_attributes)
+      AND 'muted' IN UNNEST(media_info.video_nodes_attributes)), COUNTIF(media_info.num_video_nodes > 0)) AS pages_with_video_autoplay_muted_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/video_preload.sql
+++ b/sql/2021/media/video_preload.sql
@@ -1,0 +1,48 @@
+#standardSQL
+# video preload
+
+# returns all the data we need from _media
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_video_nodes INT64,
+  video_nodes_attributes ARRAY<STRING>
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+
+    // fix "video_nodes_attributes":"[]"
+    if (!Array.isArray(media.video_nodes_attributes))
+    {
+      media.video_nodes_attributes = JSON.parse(media.video_nodes_attributes);
+    }
+
+    // skip "video_nodes_attributes":[{}]
+    if (media.video_nodes_attributes.length == 1 && Object.keys(media.video_nodes_attributes[0]).length === 0)
+    {
+      media.video_nodes_attributes = [];
+    }
+
+    result.video_nodes_attributes = media.video_nodes_attributes;
+    result.num_video_nodes = media.num_video_nodes;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  SAFE_DIVIDE(COUNTIF(media_info.num_video_nodes > 0), COUNT(0)) AS page_with_video_nodes_pct,
+  SAFE_DIVIDE(COUNTIF('preload' IN UNNEST(media_info.video_nodes_attributes)), COUNTIF(media_info.num_video_nodes > 0)) AS page_with_video_preload_pct
+FROM (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+  FROM
+    `httparchive.pages.2021_08_01_*`)
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2021/media/video_preload_values.sql
+++ b/sql/2021/media/video_preload_values.sql
@@ -1,0 +1,23 @@
+#standardSQL
+# preload attribute values
+
+SELECT
+  client,
+  LOWER(preload_value) AS preload_value,
+  COUNT(0) AS preload_value_count,
+  SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS preload_value_pct
+FROM
+  `httparchive.almanac.summary_response_bodies`,
+  # extract preload attribute value, or empty if none
+  UNNEST(REGEXP_EXTRACT_ALL(body, '<video[^>]*?preload=*(?:\"|\')*(.*?)(?:\"|\'|\\s|>)')) AS preload_value
+WHERE
+  date = '2021-08-01' AND
+  firstHtml
+GROUP BY
+  client,
+  preload_value
+HAVING
+  preload_value_count > 10
+ORDER BY
+  client,
+  preload_value_count DESC;

--- a/sql/2021/media/video_source_types.sql
+++ b/sql/2021/media/video_source_types.sql
@@ -1,0 +1,21 @@
+#standardSQL
+# get video source types
+
+SELECT
+  client,
+  LOWER(video_type) AS video_type,
+  COUNT(0) AS video_type_count,
+  SAFE_DIVIDE(COUNT(0), SUM(COUNT(0)) OVER (PARTITION BY client)) AS video_type_pct
+FROM
+  `httparchive.almanac.summary_response_bodies`,
+  UNNEST(REGEXP_EXTRACT_ALL(body, '(?i)(<video.*?</video>)')) AS video,
+  UNNEST(REGEXP_EXTRACT_ALL(video, r'(?i)type\s*=\s*["\'](video/[^\'";?]*)')) AS video_type
+WHERE
+  date = '2021-08-01' AND
+  firstHtml
+GROUP BY
+  client,
+  video_type
+ORDER BY
+  client,
+  video_type_count DESC

--- a/sql/2021/media/video_tag_and_js_player.sql
+++ b/sql/2021/media/video_tag_and_js_player.sql
@@ -1,0 +1,62 @@
+#standardSQL
+# get all pages with video nodes
+# along with all pages with video js files
+# check if video js is imported when a page has a video element or not
+
+CREATE TEMPORARY FUNCTION get_media_info(media_string STRING)
+RETURNS STRUCT<
+  num_video_nodes INT64
+> LANGUAGE js AS '''
+var result = {};
+try {
+    var media = JSON.parse(media_string);
+
+    if (Array.isArray(media) || typeof media != 'object') return result;
+
+    result.num_video_nodes = media.num_video_nodes;
+
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  client,
+  COUNTIF(video_nodes) / COUNT(0) AS video_tag_pct,
+  COUNTIF(player IS NOT NULL) / COUNT(0) AS js_video_player_pct,
+  COUNTIF(video_nodes AND player IS NOT NULL) / COUNT(0) both_video_tag_js_player_pct
+FROM (
+  SELECT
+    client,
+    media_info.num_video_nodes > 0 AS video_nodes,
+    player
+  FROM (
+    SELECT
+      _TABLE_SUFFIX AS client,
+      get_media_info(JSON_EXTRACT_SCALAR(payload, '$._media')) AS media_info
+    FROM
+      `httparchive.pages.2021_08_01_*`)
+  FULL OUTER JOIN (
+    SELECT
+      client,
+      LOWER(REGEXP_EXTRACT(url, '(?i)(hls|video|shaka|jwplayer|brightcove-player-loader|flowplayer)[(?:\\.min)]?\\.js')) AS player
+    FROM
+      `httparchive.almanac.requests`
+    WHERE
+      date = '2021-08-01' AND
+      type = 'script'
+    GROUP BY
+      client,
+      page,
+      player)
+  USING (client, url)
+  GROUP BY
+    client,
+    url,
+    video_nodes,
+    player
+  HAVING
+    video_nodes OR player IS NOT NULL)
+GROUP BY
+  client
+ORDER BY
+  client


### PR DESCRIPTION
I have added the queries from past year and updated the table to use `2021*`. 

Apart from that, I have also updated the query `image_alt.sql` to report on the attribute `decode`. The idea is to count the use of `decode=lazy`. However, I found no result in the sample data. So I am not sure if the query is completely accurate.